### PR TITLE
Add AusPost shipping method

### DIFF
--- a/auspost-shipping/includes/class-auspost-shipping-method.php
+++ b/auspost-shipping/includes/class-auspost-shipping-method.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * WooCommerce AusPost Shipping Method.
+ *
+ * Provides shipping rate calculations using the AusPost API.
+ *
+ * @link       https://paulmiller3000.com
+ * @since      1.0.0
+ *
+ * @package    Auspost_Shipping
+ * @subpackage Auspost_Shipping/includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Auspost_Shipping_Method' ) ) {
+
+    /**
+     * AusPost shipping method class.
+     */
+    class Auspost_Shipping_Method extends WC_Shipping_Method {
+
+        /**
+         * Constructor.
+         */
+        public function __construct() {
+            $this->id                 = 'auspost_shipping';
+            $this->method_title       = __( 'AusPost', 'auspost-shipping' );
+            $this->method_description = __( 'Calculate shipping rates using AusPost.', 'auspost-shipping' );
+            $this->availability       = 'including';
+            $this->countries          = array( 'AU' );
+
+            $this->init_form_fields();
+            $this->init_settings();
+
+            $this->title   = $this->get_option( 'title', __( 'AusPost Shipping', 'auspost-shipping' ) );
+            $this->enabled = $this->get_option( 'enabled', 'yes' );
+
+            add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
+        }
+
+        /**
+         * Initialise form fields for the settings page.
+         */
+        public function init_form_fields() {
+            $this->form_fields = array(
+                'enabled' => array(
+                    'title'   => __( 'Enable', 'auspost-shipping' ),
+                    'type'    => 'checkbox',
+                    'label'   => __( 'Enable AusPost shipping', 'auspost-shipping' ),
+                    'default' => 'yes',
+                ),
+                'title'   => array(
+                    'title'       => __( 'Method Title', 'auspost-shipping' ),
+                    'type'        => 'text',
+                    'description' => __( 'Title to be shown during checkout.', 'auspost-shipping' ),
+                    'default'     => __( 'AusPost Shipping', 'auspost-shipping' ),
+                    'desc_tip'    => true,
+                ),
+            );
+        }
+
+        /**
+         * Calculate shipping for a package.
+         *
+         * @param array $package Shipping package data.
+         */
+        public function calculate_shipping( $package = array() ) {
+            $rates = apply_filters( 'auspost_shipping_calculate_rates', array(), $package );
+
+            if ( empty( $rates ) ) {
+                return;
+            }
+
+            foreach ( $rates as $rate ) {
+                $this->add_rate( $rate );
+            }
+        }
+    }
+}
+

--- a/auspost-shipping/includes/class-auspost-shipping.php
+++ b/auspost-shipping/includes/class-auspost-shipping.php
@@ -72,12 +72,13 @@ class Auspost_Shipping {
 		} else {
 			$this->version = '1.0.0';
 		}
-		$this->plugin_name = 'auspost-shipping';
+               $this->plugin_name = 'auspost-shipping';
 
-		$this->load_dependencies();
-		$this->set_locale();
-		$this->define_admin_hooks();
-		$this->define_public_hooks();
+               $this->load_dependencies();
+               $this->set_locale();
+               $this->define_admin_hooks();
+               $this->define_public_hooks();
+               $this->loader->add_filter( 'woocommerce_shipping_methods', $this, 'register_shipping_method' );
 
 	}
 
@@ -120,9 +121,10 @@ class Auspost_Shipping {
 		 * The class responsible for defining all actions that occur in the public-facing
 		 * side of the site.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-auspost-shipping-public.php';
+               require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-auspost-shipping-public.php';
+               require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-auspost-shipping-method.php';
 
-		$this->loader = new Auspost_Shipping_Loader();
+               $this->loader = new Auspost_Shipping_Loader();
 
 	}
 
@@ -169,14 +171,25 @@ class Auspost_Shipping {
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	private function define_public_hooks() {
+        private function define_public_hooks() {
 
-		$plugin_public = new Auspost_Shipping_Public( $this->get_plugin_name(), $this->get_version() );
+                $plugin_public = new Auspost_Shipping_Public( $this->get_plugin_name(), $this->get_version() );
 
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+                $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
+                $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
 
-	}
+        }
+
+       /**
+        * Register the AusPost shipping method with WooCommerce.
+        *
+        * @param array $methods Existing shipping methods.
+        * @return array Filtered shipping methods including AusPost.
+        */
+       public function register_shipping_method( $methods ) {
+               $methods['auspost_shipping'] = 'Auspost_Shipping_Method';
+               return $methods;
+       }
 
 	/**
 	 * Run the loader to execute all of the hooks with WordPress.


### PR DESCRIPTION
## Summary
- add Auspost_Shipping_Method implementing constructor, settings and rate calculation stub
- register shipping method via woocommerce_shipping_methods filter

## Testing
- `php -l auspost-shipping/includes/class-auspost-shipping-method.php`
- `php -l auspost-shipping/includes/class-auspost-shipping.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd7562be7c832384d5d13ea4d35a0b