### PR TITLE
Integrate AusPost API for dynamic shipping rates

### DIFF
--- a/auspost-shipping/includes/class-auspost-api.php
+++ b/auspost-shipping/includes/class-auspost-api.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * AusPost API helper class.
+ *
+ * Handles building requests to the AusPost API and parsing responses
+ * into a format consumable by the shipping method.
+ *
+ * @link       https://paulmiller3000.com
+ * @since      1.0.0
+ *
+ * @package    Auspost_Shipping
+ * @subpackage Auspost_Shipping/includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Auspost_API' ) ) {
+
+    /**
+     * Minimal AusPost API client.
+     */
+    class Auspost_API {
+
+        /**
+         * API endpoint for requesting domestic parcel rates.
+         *
+         * @var string
+         */
+        protected $endpoint = 'https://digitalapi.auspost.com.au/postage/parcel/domestic/service.json';
+
+        /**
+         * Build a request URL for the given arguments.
+         *
+         * @param array $args Request arguments.
+         * @return string
+         */
+        public function build_request_url( $args ) {
+            $query = http_build_query( array(
+                'from_postcode' => $args['from_postcode'],
+                'to_postcode'   => $args['to_postcode'],
+                'weight'        => $args['weight'],
+            ), '', '&', PHP_QUERY_RFC3986 );
+
+            return $this->endpoint . '?' . $query;
+        }
+
+        /**
+         * Request rates from the AusPost API.
+         *
+         * Responses are cached using WordPress transients to avoid
+         * hitting the API repeatedly with the same request.
+         *
+         * @param array $args Request arguments.
+         * @return array|WP_Error Array of rate data or WP_Error on failure.
+         */
+        public function get_rates( $args ) {
+            $url       = $this->build_request_url( $args );
+            $cache_key = 'auspost_rate_' . md5( $url );
+
+            $cached = get_transient( $cache_key );
+            if ( false !== $cached ) {
+                return $cached;
+            }
+
+            $response = wp_remote_get( $url );
+
+            if ( is_wp_error( $response ) ) {
+                return $response;
+            }
+
+            $code = wp_remote_retrieve_response_code( $response );
+            if ( 200 !== $code ) {
+                return new WP_Error( 'auspost_api_error', __( 'Unexpected response from AusPost API.', 'auspost-shipping' ) );
+            }
+
+            $rates = $this->parse_response( wp_remote_retrieve_body( $response ) );
+            if ( is_wp_error( $rates ) ) {
+                return $rates;
+            }
+
+            set_transient( $cache_key, $rates, HOUR_IN_SECONDS );
+
+            return $rates;
+        }
+
+        /**
+         * Parse a JSON API response into a simplified rate array.
+         *
+         * @param string $body Response body from wp_remote_get().
+         * @return array|WP_Error Array of rates or WP_Error.
+         */
+        public function parse_response( $body ) {
+            $data = json_decode( $body, true );
+
+            if ( json_last_error() !== JSON_ERROR_NONE || empty( $data['services']['service'] ) ) {
+                return new WP_Error( 'auspost_api_invalid', __( 'Invalid response from AusPost API.', 'auspost-shipping' ) );
+            }
+
+            $rates = array();
+            foreach ( $data['services']['service'] as $service ) {
+                $rates[] = array(
+                    'code'  => $service['code'],
+                    'name'  => $service['name'],
+                    'price' => isset( $service['price'] ) ? (float) $service['price'] : 0,
+                );
+            }
+
+            return $rates;
+        }
+    }
+}

--- a/auspost-shipping/includes/class-auspost-shipping.php
+++ b/auspost-shipping/includes/class-auspost-shipping.php
@@ -117,11 +117,12 @@ class Auspost_Shipping {
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-auspost-shipping-admin.php';
 
-		/**
-		 * The class responsible for defining all actions that occur in the public-facing
-		 * side of the site.
-		 */
+               /**
+                * The class responsible for defining all actions that occur in the public-facing
+                * side of the site.
+                */
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-auspost-shipping-public.php';
+               require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-auspost-api.php';
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-auspost-shipping-method.php';
 
                $this->loader = new Auspost_Shipping_Loader();


### PR DESCRIPTION
## Summary
- add Auspost_API class to build requests, fetch and cache rates from AusPost
- wire shipping method to use API and translate returned services into WooCommerce rates
- load new API helper in plugin dependencies

## Testing
- `php -l auspost-shipping/includes/class-auspost-api.php`
- `php -l auspost-shipping/includes/class-auspost-shipping-method.php`
- `php -l auspost-shipping/includes/class-auspost-shipping.php`
- `phpcs -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd774763008323b891749c7ea087c7