### PR TITLE
Add MyPost label generation and order actions

### DIFF
--- a/auspost-shipping/includes/class-auspost-shipping.php
+++ b/auspost-shipping/includes/class-auspost-shipping.php
@@ -123,6 +123,7 @@ class Auspost_Shipping {
                 */
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-auspost-shipping-public.php';
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-auspost-api.php';
+               require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-mypost-api.php';
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-auspost-shipping-method.php';
 
                $this->loader = new Auspost_Shipping_Loader();
@@ -155,15 +156,20 @@ class Auspost_Shipping {
 	 */
 	private function define_admin_hooks() {
 
-		$plugin_admin = new Auspost_Shipping_Admin( $this->get_plugin_name(), $this->get_version() );
+               $plugin_admin = new Auspost_Shipping_Admin( $this->get_plugin_name(), $this->get_version() );
 
-		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
-		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+               $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+               $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 
-        // Add plugin settings to WooCommerce
-        $this->loader->add_filter( 'woocommerce_get_settings_pages', $plugin_admin, 'ausps_add_settings' );
-        
-	}
+       // Add plugin settings to WooCommerce
+       $this->loader->add_filter( 'woocommerce_get_settings_pages', $plugin_admin, 'ausps_add_settings' );
+
+       // MyPost label creation order actions.
+       $this->loader->add_filter( 'woocommerce_order_actions', $plugin_admin, 'add_mypost_order_action' );
+       $this->loader->add_action( 'woocommerce_order_action_mypost_create_label', $plugin_admin, 'process_mypost_create_label' );
+       $this->loader->add_action( 'woocommerce_admin_order_data_after_shipping_address', $plugin_admin, 'display_mypost_meta' );
+
+       }
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality

--- a/auspost-shipping/includes/class-mypost-api.php
+++ b/auspost-shipping/includes/class-mypost-api.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * MyPost Business API helper class.
+ *
+ * Handles authentication and label creation requests to the
+ * MyPost Business API.
+ *
+ * @link       https://paulmiller3000.com
+ * @since      1.0.0
+ *
+ * @package    Auspost_Shipping
+ * @subpackage Auspost_Shipping/includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'MyPost_API' ) ) {
+    /**
+     * Minimal MyPost Business API client.
+     */
+    class MyPost_API {
+
+        /**
+         * API endpoint for creating labels.
+         *
+         * @var string
+         */
+        protected $endpoint = 'https://digitalapi.auspost.com.au/shipping/v1/labels';
+
+        /**
+         * API key provided by MyPost Business.
+         *
+         * @var string
+         */
+        protected $api_key;
+
+        /**
+         * API secret provided by MyPost Business.
+         *
+         * @var string
+         */
+        protected $api_secret;
+
+        /**
+         * Setup client with credentials.
+         *
+         * @param string $api_key    API key.
+         * @param string $api_secret API secret.
+         */
+        public function __construct( $api_key, $api_secret ) {
+            $this->api_key    = $api_key;
+            $this->api_secret = $api_secret;
+        }
+
+        /**
+         * Build the request headers for API calls.
+         *
+         * @return array
+         */
+        protected function get_headers() {
+            return array(
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Basic ' . base64_encode( $this->api_key . ':' . $this->api_secret ),
+            );
+        }
+
+        /**
+         * Request creation of a shipping label.
+         *
+         * @param array $data Label request payload.
+         * @return array|WP_Error Label URL and tracking number on success or WP_Error on failure.
+         */
+        public function create_label( $data ) {
+            $args = array(
+                'headers' => $this->get_headers(),
+                'body'    => wp_json_encode( $data ),
+            );
+
+            $response = wp_remote_post( $this->endpoint, $args );
+
+            if ( is_wp_error( $response ) ) {
+                return $response;
+            }
+
+            $code = wp_remote_retrieve_response_code( $response );
+            if ( 201 !== $code && 200 !== $code ) {
+                return new WP_Error( 'mypost_api_error', __( 'Unexpected response from MyPost API.', 'auspost-shipping' ) );
+            }
+
+            $body = json_decode( wp_remote_retrieve_body( $response ), true );
+            if ( empty( $body['labelUrl'] ) || empty( $body['trackingNumber'] ) ) {
+                return new WP_Error( 'mypost_api_invalid', __( 'Invalid response from MyPost API.', 'auspost-shipping' ) );
+            }
+
+            return array(
+                'label_url'       => $body['labelUrl'],
+                'tracking_number' => $body['trackingNumber'],
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `MyPost_API` client for authenticated label generation
- add admin order action to create labels and store link/tracking
- show MyPost label download link and tracking number in order details

## Testing
- `php -l auspost-shipping/includes/class-mypost-api.php`
- `php -l auspost-shipping/includes/class-auspost-shipping.php`
- `php -l auspost-shipping/admin/class-auspost-shipping-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd7823e4688323a2edba462ec94d3b