### PR TITLE
Add requirement check unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 p3k-galactica.zip
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "paulmiller3000/auspost-shipping",
+    "description": "Auspost Shipping",
+    "type": "project",
+    "license": "GPL-2.0-or-later",
+    "require": {}
+}

--- a/tests/stubs/includes/class-auspost-shipping.php
+++ b/tests/stubs/includes/class-auspost-shipping.php
@@ -1,0 +1,4 @@
+<?php
+class Auspost_Shipping {
+    public function run() {}
+}

--- a/tests/test-requirements.php
+++ b/tests/test-requirements.php
@@ -1,0 +1,61 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RequirementsTest extends TestCase
+{
+    public function setUp(): void
+    {
+        \WP_Mock::setUp();
+
+        if (!defined('WPINC')) {
+            define('WPINC', 'wpinc');
+        }
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__);
+        }
+        if (!function_exists('plugin_dir_path')) {
+            function plugin_dir_path($file)
+            {
+                return __DIR__ . '/stubs/';
+            }
+        }
+
+        \WP_Mock::userFunction('is_plugin_active', [
+            'return' => true,
+        ]);
+
+        \WP_Mock::userFunction('register_activation_hook');
+        \WP_Mock::userFunction('register_deactivation_hook');
+
+        \WP_Mock::expectActionAdded('plugins_loaded', 'ausps_check_requirements');
+
+        require_once __DIR__ . '/../auspost-shipping/auspost-shipping.php';
+    }
+
+    public function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+    }
+
+    public function test_returns_true_when_woocommerce_active()
+    {
+        \WP_Mock::userFunction('is_plugin_active', [
+            'return' => true,
+            'args' => ['woocommerce/woocommerce.php'],
+        ]);
+
+        $this->assertTrue(ausps_check_requirements());
+    }
+
+    public function test_returns_false_and_hooks_notice_when_woocommerce_inactive()
+    {
+        \WP_Mock::userFunction('is_plugin_active', [
+            'return' => false,
+            'args' => ['woocommerce/woocommerce.php'],
+        ]);
+
+        \WP_Mock::expectActionAdded('admin_notices', 'ausps_missing_wc_notice');
+
+        $this->assertFalse(ausps_check_requirements());
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit/WP_Mock tests verifying WooCommerce requirement check
- include stubbed Auspost_Shipping class for test isolation

## Testing
- `composer require --dev phpunit/phpunit:^9.6 10up/wp_mock:^1.1 --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit tests/test-requirements.php` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7cf777008323ad3bc47c40cb880c