### PR TITLE
Add unit test for shipping method registration

### DIFF
--- a/tests/test-register-method.php
+++ b/tests/test-register-method.php
@@ -1,0 +1,39 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RegisterMethodTest extends TestCase
+{
+    private $auspostShipping;
+    private $loaderMock;
+
+    protected function setUp(): void
+    {
+        \WP_Mock::setUp();
+        require_once __DIR__ . '/../auspost-shipping/includes/class-auspost-shipping-loader.php';
+        require_once __DIR__ . '/../auspost-shipping/includes/class-auspost-shipping.php';
+
+        $this->loaderMock = $this->createMock(Auspost_Shipping_Loader::class);
+
+        $reflection = new ReflectionClass(Auspost_Shipping::class);
+        $this->auspostShipping = $reflection->newInstanceWithoutConstructor();
+
+        $loaderProp = $reflection->getProperty('loader');
+        $loaderProp->setAccessible(true);
+        $loaderProp->setValue($this->auspostShipping, $this->loaderMock);
+    }
+
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+    }
+
+    public function test_register_shipping_method_adds_auspost()
+    {
+        $methods = ['existing_method' => 'Existing_Method'];
+
+        $result = $this->auspostShipping->register_shipping_method($methods);
+
+        $this->assertArrayHasKey('auspost_shipping', $result);
+        $this->assertSame('Auspost_Shipping_Method', $result['auspost_shipping']);
+    }
+}


### PR DESCRIPTION
## Summary
- add test ensuring `register_shipping_method` registers `auspost_shipping`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7fba70c083239e07d896b97dcaab