### PR TITLE
chore: exclude tests from plugin distributions

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,12 @@
+# Exclude test suite
+/tests/
+
+# Exclude test configuration files
+phpunit.xml
+phpunit.xml.dist
+phpcs.xml
+phpcs.xml.dist
+phpstan.neon
+phpstan.neon.dist
+codeception.yml
+codeception.dist.yml

--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ This fork adds a new tab with two sections to the WooCommerce Settings page. For
 ## Contents
 
 * `.gitignore`. Used to exclude certain files from the repository.
+* `.distignore`. Excludes development and test files from distribution packages.
 * `README.md`. The file that you’re currently reading.
 * A `auspost-shipping` directory that contains the source code - a fully executable WordPress plugin.
+
+## Building
+
+When preparing the plugin for distribution, use a build process such as `wp dist-archive`. The `.distignore` file ensures that the `tests/` directory and any test configuration files are omitted from the resulting archive.
 
 ## Credits
 


### PR DESCRIPTION
## Summary
- add a `.distignore` to omit tests and test configuration from builds
- describe build and distribution process in the README

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd816739d08323a5b31f9b0d0851dd