### PR TITLE
Handle JSON decode errors in MyPost API

### DIFF
--- a/auspost-shipping/includes/class-mypost-api.php
+++ b/auspost-shipping/includes/class-mypost-api.php
@@ -85,9 +85,14 @@ if ( ! class_exists( 'MyPost_API' ) ) {
                 return $response;
             }
 
-            $code = wp_remote_retrieve_response_code( $response );
-            $body = json_decode( wp_remote_retrieve_body( $response ), true );
+            $code  = wp_remote_retrieve_response_code( $response );
+            $body  = json_decode( wp_remote_retrieve_body( $response ), true );
+            $error = json_last_error();
             Auspost_Shipping_Logger::log( $data, array( 'code' => $code, 'body' => $body ) );
+
+            if ( JSON_ERROR_NONE !== $error ) {
+                return new WP_Error( 'mypost_api_json_error', __( 'Unable to decode response from MyPost API.', 'auspost-shipping' ) );
+            }
 
             if ( 201 !== $code && 200 !== $code ) {
                 return new WP_Error( 'mypost_api_error', __( 'Unexpected response from MyPost API.', 'auspost-shipping' ) );


### PR DESCRIPTION
## Summary
- Guard MyPost API label creation against invalid JSON responses by checking `json_last_error`
- Return meaningful `WP_Error` when decoding fails before accessing response fields

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd84a4043c8323b86cc893b597d129