### PR TITLE
Remove duplicate id entries from settings sections

### DIFF
--- a/auspost-shipping/admin/partials/auspost-shipping-settings-main.php
+++ b/auspost-shipping/admin/partials/auspost-shipping-settings-main.php
@@ -24,7 +24,6 @@ $settings = array(
             'desc_tip'  => __( ' The name of this Battlestar Group flagship. ', 'auspost-shipping')
         ),
         array(
-            'id'        => '',
             'name'      => __( 'General Configuration', 'auspost-shipping' ),
             'type'      => 'sectionend',
             'desc'      => '',
@@ -58,7 +57,6 @@ $settings = array(
             'default'   => 'yes'
         ),             
         array(
-            'id'        => '',
             'name'      => __( 'Flagship Settings', 'auspost-shipping' ),
             'type'      => 'sectionend',
             'desc'      => '',


### PR DESCRIPTION
## Summary
- remove redundant `id` placeholders from the general and flagship settings section arrays

## Testing
- `php -l auspost-shipping/admin/partials/auspost-shipping-settings-main.php`
- `phpunit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd871d2c608323893dc5c0c365fb3e