### PR TITLE
Add dev testing dependencies and document test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ This fork adds a new tab with two sections to the WooCommerce Settings page. For
 
 When preparing the plugin for distribution, use a build process such as `wp dist-archive`. The `.distignore` file ensures that the `tests/` directory and any test configuration files are omitted from the resulting archive.
 
+## Testing
+
+Run the test suite with [PHPUnit](https://phpunit.de/):
+
+```
+vendor/bin/phpunit
+```
+
 ## Credits
 
 90% of this code was developed by the following people:

--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,9 @@
     "description": "Auspost Shipping",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "10up/wp_mock": "^0.5.0"
+    }
 }


### PR DESCRIPTION
## Summary
- Add `phpunit/phpunit` and `10up/wp_mock` to `require-dev`
- Document how to run PHPUnit tests in the README

## Testing
- `composer update` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd87ec0d248323a38a8f27b72e63ba