### PR TITLE
Check WooCommerce requirement before bootstrapping plugin

### DIFF
--- a/auspost-shipping/auspost-shipping.php
+++ b/auspost-shipping/auspost-shipping.php
@@ -87,13 +87,17 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-auspost-shipping.php';
  *
  * @since    1.0.0
  */
-function run_auspost_shipping() {
+function ausps_check_requirements() {
     if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
         $plugin = new Auspost_Shipping();
         $plugin->run();
-    } else {
-        add_action( 'admin_notices', 'ausps_missing_wc_notice' );
+
+        return true;
     }
+
+    add_action( 'admin_notices', 'ausps_missing_wc_notice' );
+
+    return false;
 }
 
-add_action( 'plugins_loaded', 'run_auspost_shipping' );
+add_action( 'plugins_loaded', 'ausps_check_requirements' );


### PR DESCRIPTION
## Summary
- Verify WooCommerce before running the plugin and display admin notice if missing
- Hook requirement check into `plugins_loaded` and drop redundant bootstrap function

## Testing
- ❌ `composer install` *(403 CONNECT tunnel failed)*
- ❌ `./vendor/bin/phpunit` *(No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a065a308323b5d6617897103119