### PR TITLE
Add API key support for AusPost requests

### DIFF
--- a/auspost-shipping/includes/class-auspost-api.php
+++ b/auspost-shipping/includes/class-auspost-api.php
@@ -31,6 +31,26 @@ if ( ! class_exists( 'Auspost_API' ) ) {
         protected $endpoint = 'https://digitalapi.auspost.com.au/postage/parcel/domestic/service.json';
 
         /**
+         * API key for authenticating requests.
+         *
+         * @var string
+         */
+        protected $api_key;
+
+        /**
+         * Constructor.
+         *
+         * @param string|null $api_key API key for the AusPost API.
+         */
+        public function __construct( $api_key = null ) {
+            if ( null === $api_key ) {
+                $api_key = get_option( 'auspost_shipping_auspost_api_key' );
+            }
+
+            $this->api_key = $api_key;
+        }
+
+        /**
          * Build a request URL for the given arguments.
          *
          * @param array $args Request arguments.
@@ -64,7 +84,14 @@ if ( ! class_exists( 'Auspost_API' ) ) {
                 return $cached;
             }
 
-            $response = wp_remote_get( $url );
+            $response = wp_remote_get(
+                $url,
+                array(
+                    'headers' => array(
+                        'auth-key' => $this->api_key,
+                    ),
+                )
+            );
 
             if ( is_wp_error( $response ) ) {
                 return $response;

--- a/tests/test-auspost-api.php
+++ b/tests/test-auspost-api.php
@@ -1,0 +1,79 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class AuspostAPITest extends TestCase
+{
+    protected function setUp(): void
+    {
+        \WP_Mock::setUp();
+        require_once __DIR__ . '/../auspost-shipping/includes/class-auspost-api.php';
+    }
+
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+    }
+
+    public function test_get_rates_sends_auth_key_header()
+    {
+        $args = [
+            'from_postcode' => '3000',
+            'to_postcode'   => '4000',
+            'weight'        => 1,
+        ];
+
+        $url = 'https://digitalapi.auspost.com.au/postage/parcel/domestic/service.json?from_postcode=3000&to_postcode=4000&weight=1';
+
+        $body = json_encode([
+            'services' => [
+                'service' => [
+                    [
+                        'code'  => 'EXP',
+                        'name'  => 'Express',
+                        'price' => '10.00',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = [
+            'body'     => $body,
+            'response' => ['code' => 200],
+        ];
+
+        \WP_Mock::userFunction('get_option', [
+            'args'   => ['auspost_shipping_auspost_api_key'],
+            'return' => 'APIKEY',
+        ]);
+        \WP_Mock::userFunction('get_transient', [
+            'return' => false,
+        ]);
+        \WP_Mock::userFunction('set_transient');
+        \WP_Mock::userFunction('is_wp_error', [
+            'return' => false,
+        ]);
+        \WP_Mock::userFunction('wp_remote_get', [
+            'args'   => [$url, ['headers' => ['auth-key' => 'APIKEY']]],
+            'return' => $response,
+        ]);
+        \WP_Mock::userFunction('wp_remote_retrieve_response_code', [
+            'args'   => [$response],
+            'return' => 200,
+        ]);
+        \WP_Mock::userFunction('wp_remote_retrieve_body', [
+            'args'   => [$response],
+            'return' => $body,
+        ]);
+
+        $api   = new Auspost_API();
+        $rates = $api->get_rates($args);
+
+        $this->assertSame([
+            ['code' => 'EXP', 'name' => 'Express', 'price' => 10.0],
+        ], $rates);
+    }
+}


### PR DESCRIPTION
## Summary
- Allow passing an AusPost API key via constructor or WordPress option
- Include the `auth-key` header on remote rate requests
- Add unit test ensuring API key is sent in requests

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a0ebe3483239dc070cd369d4323