### PR TITLE
Add security checks for MyPost label actions

### DIFF
--- a/auspost-shipping/admin/class-auspost-shipping-admin.php
+++ b/auspost-shipping/admin/class-auspost-shipping-admin.php
@@ -129,6 +129,14 @@ class Auspost_Shipping_Admin {
      * @param WC_Order $order Order object.
      */
     public function process_mypost_create_label( $order ) {
+        if ( ! current_user_can( 'manage_woocommerce' ) ) {
+            return;
+        }
+
+        if ( empty( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'woocommerce-order-actions' ) ) {
+            return;
+        }
+
         $api_key    = get_option( 'auspost_shipping_mypost_business_api_key' );
         $api_secret = get_option( 'auspost_shipping_mypost_business_api_secret' );
 
@@ -191,6 +199,10 @@ class Auspost_Shipping_Admin {
      */
     public function handle_bulk_actions( $redirect_to, $action, $order_ids ) {
         if ( 'mypost_create_labels' !== $action ) {
+            return $redirect_to;
+        }
+
+        if ( empty( $_REQUEST['mypost_create_labels_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['mypost_create_labels_nonce'] ) ), 'mypost_create_labels' ) ) {
             return $redirect_to;
         }
 

--- a/tests/test-admin-security.php
+++ b/tests/test-admin-security.php
@@ -1,0 +1,86 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class AdminSecurityTest extends TestCase
+{
+    private $admin;
+
+    protected function setUp(): void
+    {
+        \WP_Mock::setUp();
+        require_once __DIR__ . '/../auspost-shipping/admin/class-auspost-shipping-admin.php';
+        $this->admin = new Auspost_Shipping_Admin('auspost-shipping', '1.0.0');
+    }
+
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+        $_REQUEST = [];
+    }
+
+    public function test_process_mypost_create_label_requires_capability()
+    {
+        \WP_Mock::userFunction('current_user_can', [
+            'args'   => ['manage_woocommerce'],
+            'return' => false,
+            'times'  => 1,
+        ]);
+
+        $order = new stdClass();
+        $this->admin->process_mypost_create_label($order);
+    }
+
+    public function test_process_mypost_create_label_requires_nonce()
+    {
+        $_REQUEST['_wpnonce'] = 'bad';
+
+        \WP_Mock::userFunction('current_user_can', [
+            'args'   => ['manage_woocommerce'],
+            'return' => true,
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('wp_unslash', [
+            'return_arg' => 0,
+        ]);
+        \WP_Mock::userFunction('sanitize_text_field', [
+            'return_arg' => 0,
+        ]);
+        \WP_Mock::userFunction('wp_verify_nonce', [
+            'args'   => ['bad', 'woocommerce-order-actions'],
+            'return' => false,
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('get_option', [
+            'times' => 0,
+        ]);
+
+        $order = new stdClass();
+        $this->admin->process_mypost_create_label($order);
+    }
+
+    public function test_handle_bulk_actions_requires_nonce()
+    {
+        $_REQUEST['mypost_create_labels_nonce'] = 'bad';
+
+        \WP_Mock::userFunction('wp_unslash', [
+            'return_arg' => 0,
+        ]);
+        \WP_Mock::userFunction('sanitize_text_field', [
+            'return_arg' => 0,
+        ]);
+        \WP_Mock::userFunction('wp_verify_nonce', [
+            'args'   => ['bad', 'mypost_create_labels'],
+            'return' => false,
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('wc_get_order', [
+            'times' => 0,
+        ]);
+        \WP_Mock::userFunction('add_query_arg', [
+            'times' => 0,
+        ]);
+
+        $result = $this->admin->handle_bulk_actions('http://example.com', 'mypost_create_labels', [1, 2]);
+        $this->assertSame('http://example.com', $result);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce manage_woocommerce capability and order action nonce in MyPost label creation
- validate custom nonce before bulk MyPost label creation
- add unit tests for capability and nonce failure cases

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a1834e883238dae2805cd54899e