### PR TITLE
Conditionally load admin assets

### DIFF
--- a/auspost-shipping/admin/class-auspost-shipping-admin.php
+++ b/auspost-shipping/admin/class-auspost-shipping-admin.php
@@ -73,7 +73,12 @@ class Auspost_Shipping_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/auspost-shipping-admin.css', array(), $this->version, 'all' );
+               $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+               $allowed = array( 'woocommerce_page_wc-settings', 'shop_order', 'edit-shop_order' );
+
+               if ( $screen && in_array( $screen->id, $allowed, true ) ) {
+                       wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/auspost-shipping-admin.css', array(), $this->version, 'all' );
+               }
 
 	}
 
@@ -96,7 +101,12 @@ class Auspost_Shipping_Admin {
 		 * class.
 		 */
 
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/auspost-shipping-admin.js', array( 'jquery' ), $this->version, false );
+               $screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+               $allowed = array( 'woocommerce_page_wc-settings', 'shop_order', 'edit-shop_order' );
+
+               if ( $screen && in_array( $screen->id, $allowed, true ) ) {
+                       wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/auspost-shipping-admin.js', array( 'jquery' ), $this->version, false );
+               }
 
 	}
 

--- a/tests/test-admin-enqueue.php
+++ b/tests/test-admin-enqueue.php
@@ -1,0 +1,100 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class AdminEnqueueTest extends TestCase
+{
+    private Auspost_Shipping_Admin $admin;
+
+    protected function setUp(): void
+    {
+        \WP_Mock::setUp();
+        require_once __DIR__ . '/../auspost-shipping/admin/class-auspost-shipping-admin.php';
+        $this->admin = new Auspost_Shipping_Admin('auspost-shipping', '1.0.0');
+    }
+
+    protected function tearDown(): void
+    {
+        \WP_Mock::tearDown();
+    }
+
+    /**
+     * @dataProvider relevantScreens
+     */
+    public function test_enqueue_styles_on_relevant_screens(string $screen_id)
+    {
+        \WP_Mock::userFunction('get_current_screen', [
+            'return' => (object) ['id' => $screen_id],
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('wp_enqueue_style', [
+            'times' => 1,
+        ]);
+
+        $this->admin->enqueue_styles();
+    }
+
+    /**
+     * @dataProvider irrelevantScreens
+     */
+    public function test_enqueue_styles_not_on_other_screens(string $screen_id)
+    {
+        \WP_Mock::userFunction('get_current_screen', [
+            'return' => (object) ['id' => $screen_id],
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('wp_enqueue_style', [
+            'times' => 0,
+        ]);
+
+        $this->admin->enqueue_styles();
+    }
+
+    /**
+     * @dataProvider relevantScreens
+     */
+    public function test_enqueue_scripts_on_relevant_screens(string $screen_id)
+    {
+        \WP_Mock::userFunction('get_current_screen', [
+            'return' => (object) ['id' => $screen_id],
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('wp_enqueue_script', [
+            'times' => 1,
+        ]);
+
+        $this->admin->enqueue_scripts();
+    }
+
+    /**
+     * @dataProvider irrelevantScreens
+     */
+    public function test_enqueue_scripts_not_on_other_screens(string $screen_id)
+    {
+        \WP_Mock::userFunction('get_current_screen', [
+            'return' => (object) ['id' => $screen_id],
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('wp_enqueue_script', [
+            'times' => 0,
+        ]);
+
+        $this->admin->enqueue_scripts();
+    }
+
+    public function relevantScreens(): array
+    {
+        return [
+            ['woocommerce_page_wc-settings'],
+            ['shop_order'],
+            ['edit-shop_order'],
+        ];
+    }
+
+    public function irrelevantScreens(): array
+    {
+        return [
+            ['dashboard'],
+            ['plugins'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Load admin CSS/JS only on WooCommerce settings and order screens
- Test admin asset enqueue behavior across relevant and irrelevant screens

## Testing
- ⚠️ `composer install` *(failed: CONNECT tunnel failed, response 403)*
- ⚠️ `./vendor/bin/phpunit tests/test-admin-enqueue.php` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a1bf5dc8323957ad9fd7edb37b8