### PR TITLE
Clean up options on uninstall

### DIFF
--- a/auspost-shipping/uninstall.php
+++ b/auspost-shipping/uninstall.php
@@ -27,5 +27,35 @@
 
 // If uninstall not called from WordPress, then exit.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-	exit;
+        exit;
+}
+
+$option_names = array(
+    'auspost_shipping_auspost_api_key',
+    'auspost_shipping_mypost_business_api_key',
+    'auspost_shipping_mypost_business_api_secret',
+    'auspost_shipping_log',
+    'woocommerce_auspost_shipping_settings',
+);
+
+/**
+ * Delete plugin options for the current site.
+ */
+function auspost_shipping_delete_options() {
+    global $option_names;
+
+    foreach ( $option_names as $option_name ) {
+        delete_option( $option_name );
+    }
+}
+
+if ( is_multisite() ) {
+    $site_ids = get_sites( array( 'fields' => 'ids' ) );
+    foreach ( $site_ids as $site_id ) {
+        switch_to_blog( $site_id );
+        auspost_shipping_delete_options();
+        restore_current_blog();
+    }
+} else {
+    auspost_shipping_delete_options();
 }


### PR DESCRIPTION
## Summary
- Remove stored AusPost plugin options and logs when the plugin is uninstalled
- Ensure uninstall routine runs across all sites in a multisite network

## Testing
- `composer install` *(fails: curl error 56 while downloading packages)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd92d0eba083238efa8e1dcfc2add9