### PR TITLE
Check capabilities before clearing log

### DIFF
--- a/auspost-shipping/admin/class-auspost-shipping-wc-settings.php
+++ b/auspost-shipping/admin/class-auspost-shipping-wc-settings.php
@@ -120,8 +120,12 @@ if ( ! class_exists( 'Auspost_Shipping_WC_Settings' ) ) {
             switch ($current_section) {
                 case 'log':
                     if ( isset( $_GET['auspost_shipping_clear_log'] ) && check_admin_referer( 'auspost_shipping_clear_log' ) ) {
-                        Auspost_Shipping_Logger::clear();
-                        echo '<div class="updated"><p>' . esc_html__( 'Log cleared.', 'auspost-shipping' ) . '</p></div>';
+                        if ( current_user_can( 'manage_woocommerce' ) ) {
+                            Auspost_Shipping_Logger::clear();
+                            echo '<div class="updated"><p>' . esc_html__( 'Log cleared.', 'auspost-shipping' ) . '</p></div>';
+                        } else {
+                            echo '<div class="error"><p>' . esc_html__( 'You do not have permission to clear the log.', 'auspost-shipping' ) . '</p></div>';
+                        }
                     }
                     $logs = Auspost_Shipping_Logger::get_logs();
                     echo '<h2>' . esc_html__( 'API Request Log', 'auspost-shipping' ) . '</h2>';


### PR DESCRIPTION
## Summary
- ensure log clearing requires `manage_woocommerce`

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd937d64608323abaf58d02e7fc7a7