### PR TITLE
Validate MyPost credentials before creating labels

### DIFF
--- a/auspost-shipping/admin/class-auspost-shipping-admin.php
+++ b/auspost-shipping/admin/class-auspost-shipping-admin.php
@@ -147,10 +147,15 @@ class Auspost_Shipping_Admin {
             return;
         }
 
-        $api_key    = get_option( 'auspost_shipping_mypost_business_api_key' );
-        $api_secret = get_option( 'auspost_shipping_mypost_business_api_secret' );
+       $api_key    = get_option( 'auspost_shipping_mypost_business_api_key' );
+       $api_secret = get_option( 'auspost_shipping_mypost_business_api_secret' );
 
-        $api = new MyPost_API( $api_key, $api_secret );
+       if ( empty( $api_key ) || empty( $api_secret ) ) {
+               $order->add_order_note( __( 'MyPost label error: Missing API credentials.', 'auspost-shipping' ) );
+               return;
+       }
+
+       $api = new MyPost_API( $api_key, $api_secret );
 
         $payload = array(
             'order_id' => $order->get_id(),

--- a/tests/test-admin-security.php
+++ b/tests/test-admin-security.php
@@ -10,6 +10,9 @@ class AdminSecurityTest extends TestCase
         \WP_Mock::setUp();
         require_once __DIR__ . '/../auspost-shipping/admin/class-auspost-shipping-admin.php';
         $this->admin = new Auspost_Shipping_Admin('auspost-shipping', '1.0.0');
+        \WP_Mock::userFunction('__', [
+            'return_arg' => 0,
+        ]);
     }
 
     protected function tearDown(): void
@@ -56,6 +59,46 @@ class AdminSecurityTest extends TestCase
 
         $order = new stdClass();
         $this->admin->process_mypost_create_label($order);
+    }
+
+    public function test_process_mypost_create_label_requires_credentials()
+    {
+        $_REQUEST['_wpnonce'] = 'good';
+
+        \WP_Mock::userFunction('current_user_can', [
+            'args'   => ['manage_woocommerce'],
+            'return' => true,
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('wp_unslash', [
+            'return_arg' => 0,
+        ]);
+        \WP_Mock::userFunction('sanitize_text_field', [
+            'return_arg' => 0,
+        ]);
+        \WP_Mock::userFunction('wp_verify_nonce', [
+            'args'   => ['good', 'woocommerce-order-actions'],
+            'return' => true,
+            'times'  => 1,
+        ]);
+        \WP_Mock::userFunction('get_option', [
+            'return' => '',
+            'times'  => 2,
+        ]);
+
+        $order = new class {
+            public $notes = [];
+            public function add_order_note( $note ) {
+                $this->notes[] = $note;
+            }
+            public function get_id() {
+                return 1;
+            }
+        };
+
+        $this->admin->process_mypost_create_label( $order );
+
+        $this->assertSame( [ 'MyPost label error: Missing API credentials.' ], $order->notes );
     }
 
     public function test_handle_bulk_actions_requires_nonce()


### PR DESCRIPTION
## Summary
- ensure MyPost label creation aborts when API key or secret are missing
- add unit test covering missing MyPost credentials scenario

## Testing
- `php -l auspost-shipping/admin/class-auspost-shipping-admin.php`
- `php -l tests/test-admin-security.php`
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit --verbose` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68bd95c826788323b95993f88ad8f15a