### PR TITLE
Refactor settings partial to return array

### DIFF
--- a/auspost-shipping/admin/class-auspost-shipping-wc-settings.php
+++ b/auspost-shipping/admin/class-auspost-shipping-wc-settings.php
@@ -71,10 +71,10 @@ if ( ! class_exists( 'Auspost_Shipping_WC_Settings' ) ) {
                     $settings = array();
                     break;
                 default:
-                    include 'partials/auspost-shipping-settings-main.php';
+                    $main_settings = require 'partials/auspost-shipping-settings-main.php';
 
                     $settings = array_merge(
-                        $settings,
+                        $main_settings,
                         array(
                             array(
                                 'name' => __( 'API Credentials', 'auspost-shipping' ),

--- a/auspost-shipping/admin/partials/auspost-shipping-settings-main.php
+++ b/auspost-shipping/admin/partials/auspost-shipping-settings-main.php
@@ -5,62 +5,62 @@ $propulsionTypes = array(
     'ftl_speed'   => __( 'Faster Than Light', 'auspost-shipping' ),
 );
 
-$settings = array(
-        array(
-            'name' => __( 'General Configuration', 'auspost-shipping' ),
-            'type' => 'title',
-            'id'   => $prefix . 'general_config_settings'
-        ),
-        array(
-            'id'        => $prefix . 'battlestar_group',
-            'name'      => __( 'Battlestar Group', 'auspost-shipping' ), 
-            'type'      => 'number',
-            'desc_tip'  => __( ' The numeric designation of this Battlestar Group.', 'auspost-shipping')
-        ),
-        array(
-            'id'        => $prefix . 'flagship',
-            'name'      => __( 'Flagship', 'auspost-shipping' ), 
-            'type'      => 'text',
-            'desc_tip'  => __( ' The name of this Battlestar Group flagship. ', 'auspost-shipping')
-        ),
-        array(
-            'name'      => __( 'General Configuration', 'auspost-shipping' ),
-            'type'      => 'sectionend',
-            'desc'      => '',
-            'id'        => $prefix . 'general_config_settings'
-        ),
+return array(
+    array(
+        'name' => __( 'General Configuration', 'auspost-shipping' ),
+        'type' => 'title',
+        'id'   => $prefix . 'general_config_settings'
+    ),
+    array(
+        'id'        => $prefix . 'battlestar_group',
+        'name'      => __( 'Battlestar Group', 'auspost-shipping' ),
+        'type'      => 'number',
+        'desc_tip'  => __( ' The numeric designation of this Battlestar Group.', 'auspost-shipping')
+    ),
+    array(
+        'id'        => $prefix . 'flagship',
+        'name'      => __( 'Flagship', 'auspost-shipping' ),
+        'type'      => 'text',
+        'desc_tip'  => __( ' The name of this Battlestar Group flagship. ', 'auspost-shipping')
+    ),
+    array(
+        'name'      => __( 'General Configuration', 'auspost-shipping' ),
+        'type'      => 'sectionend',
+        'desc'      => '',
+        'id'        => $prefix . 'general_config_settings'
+    ),
 
-        array(
-            'name' => __( 'Flagship Settings', 'auspost-shipping' ),
-            'type' => 'title',
-            'id'   => $prefix . 'flagship_settings',
-        ),
-        array(
-            'id'        => $prefix . 'ship_propulsion_type',
-            'name'      => __( 'Propulsion Type', 'auspost-shipping' ), 
-            'type'      => 'select',
-            'class'     => 'wc-enhanced-select',
-            'options'   => $propulsionTypes,
-            'desc_tip'  => __( ' The primary propulsion type utilized by this flagship.', 'auspost-shipping')
-        ),
-        array(
-            'id'        => $prefix . 'ship_length',
-            'name'      => __( 'Length', 'auspost-shipping' ), 
-            'type'      => 'number',
-            'desc_tip'  => __( ' The length in meters of this ship.', 'auspost-shipping')
-        ),
-        array(
-            'id'        => $prefix . 'ship_in_service',
-            'name'      => __( 'In Service?', 'auspost-shipping' ),
-            'type'      => 'checkbox',
-            'desc'  => __( 'Uncheck this box if the ship is out of service.', 'auspost-shipping' ),
-            'default'   => 'yes'
-        ),             
-        array(
-            'name'      => __( 'Flagship Settings', 'auspost-shipping' ),
-            'type'      => 'sectionend',
-            'desc'      => '',
-            'id'        => $prefix . 'flagship_settings',
-        ),                        
-    );
-?>
+    array(
+        'name' => __( 'Flagship Settings', 'auspost-shipping' ),
+        'type' => 'title',
+        'id'   => $prefix . 'flagship_settings',
+    ),
+    array(
+        'id'        => $prefix . 'ship_propulsion_type',
+        'name'      => __( 'Propulsion Type', 'auspost-shipping' ),
+        'type'      => 'select',
+        'class'     => 'wc-enhanced-select',
+        'options'   => $propulsionTypes,
+        'desc_tip'  => __( ' The primary propulsion type utilized by this flagship.', 'auspost-shipping')
+    ),
+    array(
+        'id'        => $prefix . 'ship_length',
+        'name'      => __( 'Length', 'auspost-shipping' ),
+        'type'      => 'number',
+        'desc_tip'  => __( ' The length in meters of this ship.', 'auspost-shipping')
+    ),
+    array(
+        'id'        => $prefix . 'ship_in_service',
+        'name'      => __( 'In Service?', 'auspost-shipping' ),
+        'type'      => 'checkbox',
+        'desc'  => __( 'Uncheck this box if the ship is out of service.', 'auspost-shipping' ),
+        'default'   => 'yes'
+    ),
+    array(
+        'name'      => __( 'Flagship Settings', 'auspost-shipping' ),
+        'type'      => 'sectionend',
+        'desc'      => '',
+        'id'        => $prefix . 'flagship_settings',
+    ),
+);
+


### PR DESCRIPTION
## Summary
- refactor settings partial to return array instead of using shared variable
- load main settings via `require` and merge with API credential settings

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd97162bcc832388550d672a32eba5