### PR TITLE
Add PAC API key settings and client support

### DIFF
--- a/auspost-shipping/includes/class-auspost-shipping-method.php
+++ b/auspost-shipping/includes/class-auspost-shipping-method.php
@@ -66,7 +66,37 @@ if ( ! class_exists( 'Auspost_Shipping_Method' ) ) {
                     'default'     => __( 'AusPost Shipping', 'auspost-shipping' ),
                     'desc_tip'    => true,
                 ),
+                'pac_api_key' => array(
+                    'title'       => __( 'PAC API Key', 'auspost-shipping' ),
+                    'type'        => 'text',
+                    'description' => __( 'Key for accessing the AusPost PAC API.', 'auspost-shipping' ),
+                    'default'     => get_option( 'auspost_shipping_pac_api_key', '' ),
+                    'desc_tip'    => true,
+                ),
             );
+        }
+
+        /**
+         * Validate and save PAC API key field.
+         *
+         * @param string $key   Field key.
+         * @param string $value Submitted value.
+         * @return string Sanitized value.
+         */
+        public function validate_pac_api_key_field( $key, $value ) {
+            $value = sanitize_text_field( $value );
+
+            if ( empty( $value ) ) {
+                \WC_Admin_Settings::add_error( __( 'PAC API key is required.', 'auspost-shipping' ) );
+            } elseif ( ! preg_match( '/^[a-zA-Z0-9]+$/', $value ) ) {
+                \WC_Admin_Settings::add_error( __( 'PAC API key appears invalid.', 'auspost-shipping' ) );
+            } else {
+                \WC_Admin_Settings::add_message( __( 'PAC API key saved.', 'auspost-shipping' ) );
+            }
+
+            update_option( 'auspost_shipping_pac_api_key', $value );
+
+            return $value;
         }
 
         /**
@@ -155,8 +185,7 @@ if ( ! class_exists( 'Auspost_Shipping_Method' ) ) {
             if ( $contract_key && $contract_secret ) {
                 $this->rate_client = new Contract_Rate_Client( $contract_key, $contract_secret );
             } else {
-                $api_key           = get_option( 'auspost_shipping_auspost_api_key' );
-                $this->rate_client = new Pac_Rate_Client( $api_key );
+                $this->rate_client = new Pac_Rate_Client();
             }
 
             return $this->rate_client;

--- a/auspost-shipping/includes/class-pac-rate-client.php
+++ b/auspost-shipping/includes/class-pac-rate-client.php
@@ -16,6 +16,19 @@ if ( ! class_exists( 'Pac_Rate_Client' ) ) {
      */
     class Pac_Rate_Client extends Auspost_API implements Rate_Client_Interface {
         /**
+         * Constructor.
+         *
+         * @param string|null $api_key API key for PAC requests.
+         */
+        public function __construct( $api_key = null ) {
+            if ( null === $api_key ) {
+                $api_key = get_option( 'auspost_shipping_pac_api_key' );
+            }
+
+            parent::__construct( $api_key );
+        }
+
+        /**
          * Retrieve rates from the PAC service.
          *
          * Logs any WP_Error using the Auspost_Shipping_Logger and
@@ -25,6 +38,13 @@ if ( ! class_exists( 'Pac_Rate_Client' ) ) {
          * @return array List of rate arrays or empty array on failure.
          */
         public function get_rates( array $shipment ): array {
+            if ( empty( $this->api_key ) ) {
+                if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
+                    Auspost_Shipping_Logger::log( $shipment, 'Missing PAC API key.' );
+                }
+                return array();
+            }
+
             $rates = parent::get_rates( $shipment );
 
             if ( is_wp_error( $rates ) ) {

--- a/auspost-shipping/uninstall.php
+++ b/auspost-shipping/uninstall.php
@@ -32,6 +32,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 $option_names = array(
     'auspost_shipping_auspost_api_key',
+    'auspost_shipping_pac_api_key',
     'auspost_shipping_mypost_business_api_key',
     'auspost_shipping_mypost_business_api_secret',
     'auspost_shipping_log',

--- a/tests/test-pac-rate-client.php
+++ b/tests/test-pac-rate-client.php
@@ -1,0 +1,109 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Error' ) ) {
+    class WP_Error {
+        public $errors = [];
+        public function __construct( $code = '', $message = '', $data = null ) {
+            if ( $code ) {
+                $this->errors[ $code ] = [ $message ];
+            }
+        }
+        public function get_error_message() {
+            $codes = array_keys( $this->errors );
+            return $this->errors[ $codes[0] ][0];
+        }
+    }
+}
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class PacRateClientTest extends TestCase {
+    protected function setUp(): void {
+        \WP_Mock::setUp();
+        require_once __DIR__ . '/../auspost-shipping/includes/class-auspost-api.php';
+        require_once __DIR__ . '/../auspost-shipping/includes/class-pac-rate-client.php';
+    }
+
+    protected function tearDown(): void {
+        \WP_Mock::tearDown();
+    }
+
+    public function test_get_rates_uses_pac_api_key_header() {
+        $args = [
+            'from_postcode' => '3000',
+            'to_postcode'   => '4000',
+            'weight'        => 1,
+        ];
+
+        $url = 'https://digitalapi.auspost.com.au/postage/parcel/domestic/service.json?from_postcode=3000&to_postcode=4000&weight=1';
+
+        $body = json_encode([
+            'services' => [
+                'service' => [
+                    [
+                        'code'  => 'EXP',
+                        'name'  => 'Express',
+                        'price' => '10.00',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = [
+            'body'     => $body,
+            'response' => ['code' => 200],
+        ];
+
+        \WP_Mock::userFunction('get_option', [
+            'args'   => ['auspost_shipping_pac_api_key'],
+            'return' => 'APIKEY',
+        ]);
+        \WP_Mock::userFunction('get_transient', [
+            'return' => false,
+        ]);
+        \WP_Mock::userFunction('set_transient');
+        \WP_Mock::userFunction('is_wp_error', [
+            'return' => false,
+        ]);
+        \WP_Mock::userFunction('wp_remote_get', [
+            'args'   => [$url, ['headers' => ['auth-key' => 'APIKEY']]],
+            'return' => $response,
+        ]);
+        \WP_Mock::userFunction('wp_remote_retrieve_response_code', [
+            'args'   => [$response],
+            'return' => 200,
+        ]);
+        \WP_Mock::userFunction('wp_remote_retrieve_body', [
+            'args'   => [$response],
+            'return' => $body,
+        ]);
+
+        $client = new Pac_Rate_Client();
+        $rates  = $client->get_rates( $args );
+
+        $this->assertSame([
+            ['code' => 'EXP', 'name' => 'Express', 'price' => 10.0],
+        ], $rates);
+    }
+
+    public function test_get_rates_returns_empty_when_missing_key() {
+        $args = [
+            'from_postcode' => '3000',
+            'to_postcode'   => '4000',
+            'weight'        => 1,
+        ];
+
+        \WP_Mock::userFunction('get_option', [
+            'args'   => ['auspost_shipping_pac_api_key'],
+            'return' => '',
+        ]);
+
+        $client = new Pac_Rate_Client();
+        $rates  = $client->get_rates( $args );
+
+        $this->assertSame([], $rates);
+    }
+}

--- a/tests/test-shipping-method.php
+++ b/tests/test-shipping-method.php
@@ -46,6 +46,9 @@ class ShippingMethodTest extends TestCase
         \WP_Mock::userFunction('is_wp_error', [
             'return' => false,
         ]);
+        \WP_Mock::userFunction('get_option', [
+            'return' => '',
+        ]);
         \WP_Mock::userFunction('WC_Validation::is_postcode', [
             'return' => true,
         ]);
@@ -83,6 +86,8 @@ class ShippingMethodTest extends TestCase
         $this->assertSame('yes', $method->form_fields['enabled']['default']);
         $this->assertArrayHasKey('title', $method->form_fields);
         $this->assertSame('AusPost Shipping', $method->form_fields['title']['default']);
+        $this->assertArrayHasKey('pac_api_key', $method->form_fields);
+        $this->assertSame('', $method->form_fields['pac_api_key']['default']);
     }
 
     public function test_calculate_shipping_adds_rates_from_api()


### PR DESCRIPTION
## Summary
- allow entering a PAC API key in shipping method settings with validation
- use stored PAC API key in PAC rate client and inject `auth-key` header
- clean up stored PAC API key on uninstall and extend tests

## Testing
- ❌ `composer install` (failed: CONNECT tunnel failed, response 403)
- ❌ `vendor/bin/phpunit` (failed: No such file or directory)
- ✅ `php -l auspost-shipping/includes/class-auspost-shipping-method.php`
- ✅ `php -l auspost-shipping/includes/class-pac-rate-client.php`
- ✅ `php -l auspost-shipping/uninstall.php`
- ✅ `php -l tests/test-shipping-method.php`
- ✅ `php -l tests/test-pac-rate-client.php`


------
https://chatgpt.com/codex/tasks/task_e_68bda06997a08323a48021e55642acb4