### PR TITLE
Add contract account rate client with authentication and logging

### DIFF
--- a/auspost-shipping/admin/class-auspost-shipping-wc-settings.php
+++ b/auspost-shipping/admin/class-auspost-shipping-wc-settings.php
@@ -100,6 +100,24 @@ if ( ! class_exists( 'Auspost_Shipping_WC_Settings' ) ) {
                                 'desc_tip' => __( 'Secret for accessing the MyPost Business API.', 'auspost-shipping' ),
                             ),
                             array(
+                                'id'       => $prefix . 'contract_account_number',
+                                'name'     => __( 'Contract Account Number', 'auspost-shipping' ),
+                                'type'     => 'text',
+                                'desc_tip' => __( 'Account number for contracted AusPost accounts.', 'auspost-shipping' ),
+                            ),
+                            array(
+                                'id'       => $prefix . 'contract_api_key',
+                                'name'     => __( 'Contract API Key', 'auspost-shipping' ),
+                                'type'     => 'text',
+                                'desc_tip' => __( 'API key for contracted AusPost accounts.', 'auspost-shipping' ),
+                            ),
+                            array(
+                                'id'       => $prefix . 'contract_api_secret',
+                                'name'     => __( 'Contract API Secret', 'auspost-shipping' ),
+                                'type'     => 'password',
+                                'desc_tip' => __( 'API secret for contracted AusPost accounts.', 'auspost-shipping' ),
+                            ),
+                            array(
                                 'name' => __( 'API Credentials', 'auspost-shipping' ),
                                 'type' => 'sectionend',
                                 'id'   => $prefix . 'api_credentials',

--- a/auspost-shipping/includes/class-auspost-shipping-method.php
+++ b/auspost-shipping/includes/class-auspost-shipping-method.php
@@ -179,11 +179,12 @@ if ( ! class_exists( 'Auspost_Shipping_Method' ) ) {
                 return $this->rate_client;
             }
 
-            $contract_key    = get_option( 'auspost_shipping_mypost_business_api_key' );
-            $contract_secret = get_option( 'auspost_shipping_mypost_business_api_secret' );
+            $contract_account = get_option( 'auspost_shipping_contract_account_number' );
+            $contract_key     = get_option( 'auspost_shipping_contract_api_key' );
+            $contract_secret  = get_option( 'auspost_shipping_contract_api_secret' );
 
-            if ( $contract_key && $contract_secret ) {
-                $this->rate_client = new Contract_Rate_Client( $contract_key, $contract_secret );
+            if ( $contract_account && $contract_key && $contract_secret ) {
+                $this->rate_client = new Contract_Rate_Client( $contract_account, $contract_key, $contract_secret );
             } else {
                 $this->rate_client = new Pac_Rate_Client();
             }

--- a/auspost-shipping/includes/class-contract-rate-client.php
+++ b/auspost-shipping/includes/class-contract-rate-client.php
@@ -20,34 +20,59 @@ if ( ! class_exists( 'Contract_Rate_Client' ) ) {
         protected $endpoint = 'https://digitalapi.auspost.com.au/shipping/v1/prices/parcel/domestic';
 
         /**
-         * Username for basic auth.
+         * Contract account number.
          *
          * @var string
          */
-        protected $username;
+        protected $account_number;
 
         /**
-         * Password for basic auth.
+         * API key for basic auth.
          *
          * @var string
          */
-        protected $password;
+        protected $api_key;
+
+        /**
+         * API secret for basic auth.
+         *
+         * @var string
+         */
+        protected $api_secret;
+
+        /**
+         * Service codes to request. Includes both eParcel and StarTrack codes.
+         *
+         * @var array
+         */
+        protected $service_codes = array(
+            'AUS_PARCEL_REGULAR',
+            'AUS_PARCEL_EXPRESS',
+            'EXP',
+            'EXP_PLAT',
+        );
 
         /**
          * Setup credentials.
          *
-         * @param string|null $username API username.
-         * @param string|null $password API password.
+         * @param string|null $account_number Contract account number.
+         * @param string|null $api_key        API key.
+         * @param string|null $api_secret     API secret.
          */
-        public function __construct( $username = null, $password = null ) {
-            if ( null === $username ) {
-                $username = get_option( 'auspost_shipping_mypost_business_api_key' );
+        public function __construct( $account_number = null, $api_key = null, $api_secret = null ) {
+            if ( null === $account_number ) {
+                $account_number = get_option( 'auspost_shipping_contract_account_number' );
             }
-            if ( null === $password ) {
-                $password = get_option( 'auspost_shipping_mypost_business_api_secret' );
+            if ( null === $api_key ) {
+                $api_key = get_option( 'auspost_shipping_contract_api_key' );
             }
-            $this->username = (string) $username;
-            $this->password = (string) $password;
+            if ( null === $api_secret ) {
+                $api_secret = get_option( 'auspost_shipping_contract_api_secret' );
+            }
+
+            $this->account_number = (string) $account_number;
+            $this->api_key        = (string) $api_key;
+            $this->api_secret     = (string) $api_secret;
         }
 
         /**
@@ -57,18 +82,35 @@ if ( ! class_exists( 'Contract_Rate_Client' ) ) {
          * @return array List of rates or empty array on failure.
          */
         public function get_rates( array $shipment ): array {
-            $cache_key = 'auspost_contract_' . md5( wp_json_encode( $shipment ) );
-            $cached = get_transient( $cache_key );
+            if ( empty( $this->account_number ) || empty( $this->api_key ) || empty( $this->api_secret ) ) {
+                if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
+                    Auspost_Shipping_Logger::log( $shipment, 'Missing contract credentials.' );
+                }
+                return array();
+            }
+
+            $cache_key = 'auspost_contract_' . md5( $this->account_number . wp_json_encode( $shipment ) );
+            $cached    = get_transient( $cache_key );
             if ( false !== $cached ) {
                 return $cached;
             }
 
+            $payload = array(
+                'account-number' => $this->account_number,
+                'from'           => array( 'postcode' => $shipment['from_postcode'] ),
+                'to'             => array( 'postcode' => $shipment['to_postcode'] ),
+                'items'          => array(
+                    array( 'weight' => $shipment['weight'] ),
+                ),
+                'service-codes'  => $this->service_codes,
+            );
+
             $args = array(
                 'headers' => array(
-                    'Authorization' => 'Basic ' . base64_encode( $this->username . ':' . $this->password ),
+                    'Authorization' => 'Basic ' . base64_encode( $this->api_key . ':' . $this->api_secret ),
                     'Content-Type'  => 'application/json',
                 ),
-                'body'    => wp_json_encode( $shipment ),
+                'body'    => wp_json_encode( $payload ),
                 'timeout' => 15,
             );
 
@@ -76,33 +118,54 @@ if ( ! class_exists( 'Contract_Rate_Client' ) ) {
 
             if ( is_wp_error( $response ) ) {
                 if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
-                    Auspost_Shipping_Logger::log( $shipment, $response->get_error_message() );
+                    Auspost_Shipping_Logger::log( $payload, $response->get_error_message() );
                 }
                 return array();
             }
 
-            $code = wp_remote_retrieve_response_code( $response );
+            $code     = wp_remote_retrieve_response_code( $response );
+            $body_raw = wp_remote_retrieve_body( $response );
+
+            if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
+                Auspost_Shipping_Logger::log( $payload, array( 'code' => $code, 'body' => $body_raw ) );
+            }
+
+            if ( 401 === $code || 403 === $code ) {
+                if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
+                    Auspost_Shipping_Logger::log( $payload, 'Invalid credentials' );
+                }
+                return array();
+            }
+
+            if ( 503 === $code ) {
+                if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
+                    Auspost_Shipping_Logger::log( $payload, 'Service unavailable' );
+                }
+                return array();
+            }
+
             if ( 200 !== $code ) {
-                if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
-                    Auspost_Shipping_Logger::log( $shipment, array( 'code' => $code, 'body' => wp_remote_retrieve_body( $response ) ) );
-                }
                 return array();
             }
 
-            $body = json_decode( wp_remote_retrieve_body( $response ), true );
-            if ( json_last_error() !== JSON_ERROR_NONE || empty( $body['prices'] ) ) {
+            $body  = json_decode( $body_raw, true );
+            $error = json_last_error();
+            if ( JSON_ERROR_NONE !== $error || empty( $body['prices'] ) ) {
                 if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
-                    Auspost_Shipping_Logger::log( $shipment, wp_remote_retrieve_body( $response ) );
+                    Auspost_Shipping_Logger::log( $payload, $body_raw );
                 }
                 return array();
             }
 
             $rates = array();
             foreach ( $body['prices'] as $price ) {
+                $code  = isset( $price['service-code'] ) ? $price['service-code'] : ( $price['product']['code'] ?? '' );
+                $name  = isset( $price['service-name'] ) ? $price['service-name'] : ( $price['product']['description'] ?? '' );
+                $cost  = isset( $price['total-cost'] ) ? $price['total-cost'] : ( $price['total_price'] ?? 0 );
                 $rates[] = array(
-                    'code'  => isset( $price['product']['code'] ) ? $price['product']['code'] : '',
-                    'name'  => isset( $price['product']['description'] ) ? $price['product']['description'] : '',
-                    'price' => isset( $price['total_price'] ) ? (float) $price['total_price'] : 0,
+                    'code'  => $code,
+                    'name'  => $name,
+                    'price' => (float) $cost,
                 );
             }
 
@@ -112,3 +175,4 @@ if ( ! class_exists( 'Contract_Rate_Client' ) ) {
         }
     }
 }
+

--- a/auspost-shipping/uninstall.php
+++ b/auspost-shipping/uninstall.php
@@ -35,6 +35,9 @@ $option_names = array(
     'auspost_shipping_pac_api_key',
     'auspost_shipping_mypost_business_api_key',
     'auspost_shipping_mypost_business_api_secret',
+    'auspost_shipping_contract_account_number',
+    'auspost_shipping_contract_api_key',
+    'auspost_shipping_contract_api_secret',
     'auspost_shipping_log',
     'woocommerce_auspost_shipping_settings',
 );

--- a/tests/test-contract-rate-client.php
+++ b/tests/test-contract-rate-client.php
@@ -1,0 +1,134 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+    function wp_json_encode( $data ) {
+        return json_encode( $data );
+    }
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+    class WP_Error {
+        public function __construct( $code = '', $message = '' ) {}
+        public function get_error_message() { return ''; }
+    }
+}
+
+if ( ! class_exists( 'Auspost_Shipping_Logger' ) ) {
+    class Auspost_Shipping_Logger {
+        public static function log( $request, $response ) {}
+    }
+}
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class ContractRateClientTest extends TestCase {
+    protected function setUp(): void {
+        \WP_Mock::setUp();
+        require_once __DIR__ . '/../auspost-shipping/includes/class-contract-rate-client.php';
+    }
+
+    protected function tearDown(): void {
+        \WP_Mock::tearDown();
+    }
+
+    public function test_get_rates_sends_basic_auth_and_service_codes() {
+        $shipment = [
+            'from_postcode' => '3000',
+            'to_postcode'   => '4000',
+            'weight'        => 1,
+        ];
+
+        $payload = wp_json_encode([
+            'account-number' => 'ACC123',
+            'from' => ['postcode' => '3000'],
+            'to' => ['postcode' => '4000'],
+            'items' => [ ['weight' => 1] ],
+            'service-codes' => ['AUS_PARCEL_REGULAR','AUS_PARCEL_EXPRESS','EXP','EXP_PLAT'],
+        ]);
+
+        $response_body = json_encode([
+            'prices' => [
+                [
+                    'service-code' => 'AUS_PARCEL_REGULAR',
+                    'service-name' => 'Parcel Post',
+                    'total-cost'   => 9.95,
+                ],
+            ],
+        ]);
+        $response = ['body' => $response_body, 'response' => ['code' => 200]];
+
+        \WP_Mock::userFunction( 'get_transient', [ 'return' => false ] );
+        \WP_Mock::userFunction( 'set_transient' );
+        \WP_Mock::userFunction( 'wp_remote_post', [
+            'args' => [
+                'https://digitalapi.auspost.com.au/shipping/v1/prices/parcel/domestic',
+                [
+                    'headers' => [
+                        'Authorization' => 'Basic ' . base64_encode( 'key:secret' ),
+                        'Content-Type'  => 'application/json',
+                    ],
+                    'body'    => $payload,
+                    'timeout' => 15,
+                ],
+            ],
+            'return' => $response,
+        ] );
+        \WP_Mock::userFunction( 'is_wp_error', [ 'args' => [ $response ], 'return' => false ] );
+        \WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'args' => [ $response ], 'return' => 200 ] );
+        \WP_Mock::userFunction( 'wp_remote_retrieve_body', [ 'args' => [ $response ], 'return' => $response_body ] );
+
+        $client = new Contract_Rate_Client( 'ACC123', 'key', 'secret' );
+        $rates  = $client->get_rates( $shipment );
+
+        $this->assertSame([
+            ['code' => 'AUS_PARCEL_REGULAR', 'name' => 'Parcel Post', 'price' => 9.95],
+        ], $rates);
+    }
+
+    public function test_get_rates_returns_empty_on_invalid_credentials() {
+        $shipment = [
+            'from_postcode' => '3000',
+            'to_postcode'   => '4000',
+            'weight'        => 1,
+        ];
+
+        $payload = wp_json_encode([
+            'account-number' => 'ACC123',
+            'from' => ['postcode' => '3000'],
+            'to' => ['postcode' => '4000'],
+            'items' => [ ['weight' => 1] ],
+            'service-codes' => ['AUS_PARCEL_REGULAR','AUS_PARCEL_EXPRESS','EXP','EXP_PLAT'],
+        ]);
+
+        $response = ['body' => '{}', 'response' => ['code' => 401]];
+
+        \WP_Mock::userFunction( 'get_transient', [ 'return' => false ] );
+        \WP_Mock::userFunction( 'wp_remote_post', [
+            'args' => [
+                'https://digitalapi.auspost.com.au/shipping/v1/prices/parcel/domestic',
+                [
+                    'headers' => [
+                        'Authorization' => 'Basic ' . base64_encode( 'key:secret' ),
+                        'Content-Type'  => 'application/json',
+                    ],
+                    'body'    => $payload,
+                    'timeout' => 15,
+                ],
+            ],
+            'return' => $response,
+        ] );
+        \WP_Mock::userFunction( 'is_wp_error', [ 'args' => [ $response ], 'return' => false ] );
+        \WP_Mock::userFunction( 'wp_remote_retrieve_response_code', [ 'args' => [ $response ], 'return' => 401 ] );
+        \WP_Mock::userFunction( 'wp_remote_retrieve_body', [ 'args' => [ $response ], 'return' => '{}' ] );
+        \WP_Mock::userFunction( 'Auspost_Shipping_Logger::log' );
+
+        $client = new Contract_Rate_Client( 'ACC123', 'key', 'secret' );
+        $rates  = $client->get_rates( $shipment );
+
+        $this->assertSame( [], $rates );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add settings fields for contract account number, API key and secret
- implement new Contract_Rate_Client with Basic Auth, service-code support and error handling
- update shipping method to use contract credentials and clean up on uninstall
- add unit tests for contract rate client

## Testing
- `composer install` (fails: CONNECT tunnel failed, response 403)
- `vendor/bin/phpunit` (fails: No such file or directory)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bda20c14008323b3df1e46bf4aa5a6