### PR TITLE
Add box packing and admin box settings

### DIFF
--- a/auspost-shipping/admin/class-box-settings.php
+++ b/auspost-shipping/admin/class-box-settings.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Admin UI for defining shipping boxes.
+ *
+ * @package Auspost_Shipping\admin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Auspost_Box_Settings' ) ) {
+    class Auspost_Box_Settings {
+        /**
+         * Register menu entry.
+         */
+        public function register_menu() {
+            add_submenu_page(
+                'woocommerce',
+                __( 'Shipping Boxes', 'auspost-shipping' ),
+                __( 'Shipping Boxes', 'auspost-shipping' ),
+                'manage_woocommerce',
+                'auspost-shipping-boxes',
+                array( $this, 'render_page' )
+            );
+        }
+
+        /**
+         * Register setting.
+         */
+        public function register_settings() {
+            register_setting( 'auspost_shipping_boxes_group', 'auspost_shipping_boxes' );
+        }
+
+        /**
+         * Render admin page.
+         */
+        public function render_page() {
+            if ( ! current_user_can( 'manage_woocommerce' ) ) {
+                return;
+            }
+
+            if ( isset( $_POST['auspost_boxes_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['auspost_boxes_nonce'] ) ), 'auspost_boxes_save' ) ) {
+                $boxes = array();
+                if ( isset( $_POST['boxes'] ) && is_array( $_POST['boxes'] ) ) {
+                    foreach ( $_POST['boxes'] as $box ) {
+                        $length = isset( $box['length'] ) ? floatval( $box['length'] ) : 0;
+                        $width  = isset( $box['width'] ) ? floatval( $box['width'] ) : 0;
+                        $height = isset( $box['height'] ) ? floatval( $box['height'] ) : 0;
+                        $max_w  = isset( $box['max_weight'] ) ? floatval( $box['max_weight'] ) : 0;
+                        $pad    = isset( $box['padding'] ) ? floatval( $box['padding'] ) : 0;
+                        if ( $length && $width && $height ) {
+                            $boxes[] = array(
+                                'length'     => $length,
+                                'width'      => $width,
+                                'height'     => $height,
+                                'max_weight' => $max_w,
+                                'padding'    => $pad,
+                            );
+                        }
+                    }
+                }
+                update_option( 'auspost_shipping_boxes', $boxes );
+                echo '<div class="updated"><p>' . esc_html__( 'Boxes saved.', 'auspost-shipping' ) . '</p></div>';
+            }
+
+            $boxes = get_option( 'auspost_shipping_boxes', array() );
+            ?>
+            <div class="wrap">
+                <h1><?php esc_html_e( 'Shipping Boxes', 'auspost-shipping' ); ?></h1>
+                <form method="post" action="">
+                    <?php wp_nonce_field( 'auspost_boxes_save', 'auspost_boxes_nonce' ); ?>
+                    <table class="widefat">
+                        <thead>
+                            <tr>
+                                <th><?php esc_html_e( 'Length (cm)', 'auspost-shipping' ); ?></th>
+                                <th><?php esc_html_e( 'Width (cm)', 'auspost-shipping' ); ?></th>
+                                <th><?php esc_html_e( 'Height (cm)', 'auspost-shipping' ); ?></th>
+                                <th><?php esc_html_e( 'Max Weight (kg)', 'auspost-shipping' ); ?></th>
+                                <th><?php esc_html_e( 'Padding (cm)', 'auspost-shipping' ); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if ( $boxes ) : ?>
+                                <?php foreach ( $boxes as $index => $box ) : ?>
+                                    <tr>
+                                        <td><input type="number" step="0.01" name="boxes[<?php echo esc_attr( $index ); ?>][length]" value="<?php echo esc_attr( $box['length'] ); ?>" /></td>
+                                        <td><input type="number" step="0.01" name="boxes[<?php echo esc_attr( $index ); ?>][width]" value="<?php echo esc_attr( $box['width'] ); ?>" /></td>
+                                        <td><input type="number" step="0.01" name="boxes[<?php echo esc_attr( $index ); ?>][height]" value="<?php echo esc_attr( $box['height'] ); ?>" /></td>
+                                        <td><input type="number" step="0.01" name="boxes[<?php echo esc_attr( $index ); ?>][max_weight]" value="<?php echo esc_attr( $box['max_weight'] ); ?>" /></td>
+                                        <td><input type="number" step="0.01" name="boxes[<?php echo esc_attr( $index ); ?>][padding]" value="<?php echo esc_attr( $box['padding'] ); ?>" /></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                            <tr>
+                                <td><input type="number" step="0.01" name="boxes[new][length]" /></td>
+                                <td><input type="number" step="0.01" name="boxes[new][width]" /></td>
+                                <td><input type="number" step="0.01" name="boxes[new][height]" /></td>
+                                <td><input type="number" step="0.01" name="boxes[new][max_weight]" /></td>
+                                <td><input type="number" step="0.01" name="boxes[new][padding]" /></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <?php submit_button( __( 'Save Boxes', 'auspost-shipping' ) ); ?>
+                </form>
+            </div>
+            <?php
+        }
+    }
+}
+

--- a/auspost-shipping/includes/class-auspost-shipping-method.php
+++ b/auspost-shipping/includes/class-auspost-shipping-method.php
@@ -113,6 +113,7 @@ if ( ! class_exists( 'Auspost_Shipping_Method' ) ) {
             $destination_country = isset( $package['destination']['country'] ) ? $package['destination']['country'] : WC()->countries->get_base_country();
             $to_postcode         = isset( $package['destination']['postcode'] ) ? wc_format_postcode( $package['destination']['postcode'], $destination_country ) : '';
             $weight              = isset( $package['contents_weight'] ) ? $package['contents_weight'] : 0;
+            $boxes               = get_option( 'auspost_shipping_boxes', array() );
 
             if ( ! WC_Validation::is_postcode( $to_postcode, $destination_country ) ) {
                 if ( class_exists( 'Auspost_Shipping_Logger' ) ) {
@@ -123,6 +124,74 @@ if ( ! class_exists( 'Auspost_Shipping_Method' ) ) {
                             'weight'        => $weight,
                         ),
                         'Missing or invalid destination postcode.'
+                    );
+                }
+                return;
+            }
+
+            if ( ! empty( $boxes ) && ! empty( $package['contents'] ) ) {
+                $items = array();
+                foreach ( $package['contents'] as $item ) {
+                    $qty = isset( $item['quantity'] ) ? (int) $item['quantity'] : 1;
+                    if ( isset( $item['data'] ) && is_object( $item['data'] ) ) {
+                        $product = $item['data'];
+                        $length  = wc_get_dimension( method_exists( $product, 'get_length' ) ? $product->get_length() : 0, 'cm' );
+                        $width   = wc_get_dimension( method_exists( $product, 'get_width' ) ? $product->get_width() : 0, 'cm' );
+                        $height  = wc_get_dimension( method_exists( $product, 'get_height' ) ? $product->get_height() : 0, 'cm' );
+                        $w       = wc_get_weight( method_exists( $product, 'get_weight' ) ? $product->get_weight() : 0, 'kg' );
+                    } else {
+                        $length = wc_get_dimension( isset( $item['length'] ) ? $item['length'] : 0, 'cm' );
+                        $width  = wc_get_dimension( isset( $item['width'] ) ? $item['width'] : 0, 'cm' );
+                        $height = wc_get_dimension( isset( $item['height'] ) ? $item['height'] : 0, 'cm' );
+                        $w      = wc_get_weight( isset( $item['weight'] ) ? $item['weight'] : 0, 'kg' );
+                    }
+                    $items[] = array(
+                        'length' => (float) $length,
+                        'width'  => (float) $width,
+                        'height' => (float) $height,
+                        'weight' => (float) $w,
+                        'qty'    => $qty,
+                    );
+                }
+
+                $packer   = new Box_Packer( $boxes );
+                $packages = $packer->pack( $items );
+                if ( $packer->get_unpacked_items() ) {
+                    return; // Unable to pack all items
+                }
+
+                $totals = array();
+                foreach ( $packages as $pkg ) {
+                    $shipment = array(
+                        'from_postcode' => $from_postcode,
+                        'to_postcode'   => $to_postcode,
+                        'weight'        => wc_get_weight( $pkg['weight'], 'kg' ),
+                        'length'        => $pkg['length'],
+                        'width'         => $pkg['width'],
+                        'height'        => $pkg['height'],
+                    );
+                    $rates = $this->get_rate_client()->get_rates( $shipment );
+                    foreach ( $rates as $rate ) {
+                        if ( isset( $totals[ $rate['code'] ] ) ) {
+                            $totals[ $rate['code'] ]['price'] += $rate['price'];
+                        } else {
+                            $totals[ $rate['code'] ] = $rate;
+                        }
+                    }
+                }
+
+                if ( empty( $totals ) ) {
+                    return;
+                }
+
+                foreach ( $totals as $rate ) {
+                    $this->add_rate(
+                        array(
+                            'id'      => $this->id . ':' . $rate['code'],
+                            'label'   => $rate['name'],
+                            'cost'    => $rate['price'],
+                            'package' => $package,
+                        )
                     );
                 }
                 return;

--- a/auspost-shipping/includes/class-auspost-shipping.php
+++ b/auspost-shipping/includes/class-auspost-shipping.php
@@ -115,7 +115,8 @@ class Auspost_Shipping {
 		/**
 		 * The class responsible for defining all actions that occur in the admin area.
 		 */
-		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-auspost-shipping-admin.php';
+               require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-auspost-shipping-admin.php';
+               require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-box-settings.php';
 
                /**
                 * The class responsible for defining all actions that occur in the public-facing
@@ -129,6 +130,7 @@ class Auspost_Shipping {
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-mypost-api.php';
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-auspost-shipping-logger.php';
                require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-auspost-shipping-method.php';
+               require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-box-packer.php';
 
                $this->loader = new Auspost_Shipping_Loader();
 
@@ -160,13 +162,18 @@ class Auspost_Shipping {
 	 */
 	private function define_admin_hooks() {
 
-               $plugin_admin = new Auspost_Shipping_Admin( $this->get_plugin_name(), $this->get_version() );
+              $plugin_admin = new Auspost_Shipping_Admin( $this->get_plugin_name(), $this->get_version() );
+              $box_settings = new Auspost_Box_Settings();
 
-               $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
-               $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+              $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+              $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 
        // Add plugin settings to WooCommerce
        $this->loader->add_filter( 'woocommerce_get_settings_pages', $plugin_admin, 'ausps_add_settings' );
+
+       // Box settings page
+       $this->loader->add_action( 'admin_menu', $box_settings, 'register_menu' );
+       $this->loader->add_action( 'admin_init', $box_settings, 'register_settings' );
 
        // MyPost label creation order actions.
        $this->loader->add_filter( 'woocommerce_order_actions', $plugin_admin, 'add_mypost_order_action' );

--- a/auspost-shipping/includes/class-box-packer.php
+++ b/auspost-shipping/includes/class-box-packer.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Box packing utility.
+ *
+ * Accepts items with dimensions and weight and packs them into
+ * configured boxes while respecting box limits. The final
+ * package weight is the greater of the actual and dimensional
+ * weights.
+ *
+ * @package Auspost_Shipping\includes
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Box_Packer' ) ) {
+    class Box_Packer {
+        /**
+         * Available boxes.
+         *
+         * Each box is an associative array with keys:
+         * length, width, height, max_weight, padding
+         *
+         * @var array
+         */
+        protected $boxes = array();
+
+        /**
+         * Items that could not be packed.
+         *
+         * @var array
+         */
+        protected $unpacked = array();
+
+        /**
+         * Constructor.
+         *
+         * @param array $boxes List of available boxes.
+         */
+        public function __construct( array $boxes ) {
+            // sort boxes from smallest to largest volume
+            usort( $boxes, function( $a, $b ) {
+                $vol_a = $a['length'] * $a['width'] * $a['height'];
+                $vol_b = $b['length'] * $b['width'] * $b['height'];
+                return $vol_a <=> $vol_b;
+            } );
+            $this->boxes = $boxes;
+        }
+
+        /**
+         * Pack items into boxes.
+         *
+         * @param array $items Items to pack. Each item should have
+         *                     length, width, height, weight, qty.
+         * @return array Packed packages with length, width, height, weight.
+         */
+        public function pack( array $items ) {
+            $packages = array();
+            $this->unpacked = array();
+
+            foreach ( $items as $item ) {
+                $qty = isset( $item['qty'] ) ? (int) $item['qty'] : 1;
+                for ( $i = 0; $i < $qty; $i++ ) {
+                    $single = $item;
+                    $single['qty'] = 1;
+                    if ( ! $this->place_item_in_packages( $single, $packages ) ) {
+                        if ( ! $this->start_new_package( $single, $packages ) ) {
+                            $this->unpacked[] = $single;
+                        }
+                    }
+                }
+            }
+
+            // Finalise packages and compute dimensional weight
+            foreach ( $packages as &$pkg ) {
+                $box = $pkg['box'];
+                $pkg['length'] = $box['length'];
+                $pkg['width']  = $box['width'];
+                $pkg['height'] = $box['height'];
+                $dim_weight = ( $box['length'] * $box['width'] * $box['height'] ) / 5000; // cm^3 to kg
+                $pkg['weight'] = max( $pkg['weight'], $dim_weight );
+                unset( $pkg['box'], $pkg['used_volume'] );
+            }
+
+            return $packages;
+        }
+
+        /**
+         * Get unpacked items.
+         *
+         * @return array
+         */
+        public function get_unpacked_items() {
+            return $this->unpacked;
+        }
+
+        /**
+         * Try to place an item into existing packages.
+         *
+         * @param array $item     Item data.
+         * @param array &$packages Current packages.
+         * @return bool True if placed.
+         */
+        protected function place_item_in_packages( $item, &$packages ) {
+            foreach ( $packages as &$pkg ) {
+                $box = $pkg['box'];
+                $inner_length = $box['length'] - 2 * $box['padding'];
+                $inner_width  = $box['width']  - 2 * $box['padding'];
+                $inner_height = $box['height'] - 2 * $box['padding'];
+                $item_vol = $item['length'] * $item['width'] * $item['height'];
+                $box_vol  = $inner_length * $inner_width * $inner_height;
+
+                if ( $item['length'] <= $inner_length &&
+                     $item['width']  <= $inner_width &&
+                     $item['height'] <= $inner_height &&
+                     $pkg['weight'] + $item['weight'] <= $box['max_weight'] &&
+                     $pkg['used_volume'] + $item_vol <= $box_vol ) {
+                    $pkg['weight']      += $item['weight'];
+                    $pkg['used_volume'] += $item_vol;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Start a new package with the smallest fitting box.
+         *
+         * @param array $item Item data.
+         * @param array &$packages Packages array.
+         * @return bool True if package created.
+         */
+        protected function start_new_package( $item, &$packages ) {
+            foreach ( $this->boxes as $box ) {
+                $inner_length = $box['length'] - 2 * $box['padding'];
+                $inner_width  = $box['width']  - 2 * $box['padding'];
+                $inner_height = $box['height'] - 2 * $box['padding'];
+
+                if ( $item['length'] <= $inner_length &&
+                     $item['width']  <= $inner_width &&
+                     $item['height'] <= $inner_height &&
+                     $item['weight'] <= $box['max_weight'] ) {
+                    $pkg = array(
+                        'box'         => $box,
+                        'weight'      => $item['weight'],
+                        'used_volume' => $item['length'] * $item['width'] * $item['height'],
+                    );
+                    $packages[] = $pkg;
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}
+

--- a/tests/test-box-packer.php
+++ b/tests/test-box-packer.php
@@ -1,0 +1,43 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../auspost-shipping/includes/class-box-packer.php';
+
+class BoxPackerTest extends TestCase
+{
+    public function test_overflow_unpacked_items()
+    {
+        $boxes = [
+            ['length' => 10, 'width' => 10, 'height' => 10, 'max_weight' => 5, 'padding' => 0],
+        ];
+        $items = [
+            ['length' => 20, 'width' => 20, 'height' => 20, 'weight' => 1, 'qty' => 1],
+        ];
+
+        $packer = new Box_Packer($boxes);
+        $packages = $packer->pack($items);
+
+        $this->assertCount(0, $packages);
+        $this->assertCount(1, $packer->get_unpacked_items());
+    }
+
+    public function test_dimensional_weight_used()
+    {
+        $boxes = [
+            ['length' => 100, 'width' => 100, 'height' => 100, 'max_weight' => 50, 'padding' => 0],
+        ];
+        $items = [
+            ['length' => 50, 'width' => 50, 'height' => 50, 'weight' => 1, 'qty' => 1],
+        ];
+
+        $packer = new Box_Packer($boxes);
+        $packages = $packer->pack($items);
+
+        $this->assertCount(1, $packages);
+        $pkg = $packages[0];
+        $actual = 1; // actual weight
+        $dim = (100*100*100)/5000; // 200 kg
+        $this->assertEquals($dim, $pkg['weight']);
+        $this->assertGreaterThan($actual, $pkg['weight']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Box_Packer` utility to optimise items into boxes and compare dimensional vs actual weight
- introduce admin interface to manage reusable shipping boxes
- update shipping method to pack cart contents and aggregate multi-package rates
- include PHPUnit tests covering overflow and volumetric weight cases

## Testing
- `composer install` (failed: CONNECT tunnel failed, response 403)
- `./vendor/bin/phpunit -q` (command not found)
- `phpunit` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bda3623aa08323aa66717aeb37a7fa