### PR TITLE
Add tests for rate clients and packing, document API setup and hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,44 @@ Run the test suite with [PHPUnit](https://phpunit.de/):
 vendor/bin/phpunit
 ```
 
+## API Configuration
+
+The shipping method supports both public PAC and contracted account APIs.
+1. Enter your PAC or contracted credentials in **WooCommerce → Settings → Shipping → AusPost**.
+2. Choose the appropriate account type and save your API key, account number, and secrets as required.
+
+## Box Definitions
+
+Boxes used for packing can be configured under **WooCommerce → Settings → Shipping → AusPost → Boxes**. Each box requires length, width, height, maximum weight and padding values. The smallest fitting box is used and dimensional weight is applied automatically.
+
+## Developer Hooks
+
+Developers can extend packing and rate selection using filters and actions:
+
+```php
+// Add or modify available boxes before packing.
+add_filter( 'auspost_shipping_boxes', function( $boxes ) {
+    $boxes[] = [
+        'length' => 20,
+        'width'  => 20,
+        'height' => 20,
+        'max_weight' => 10,
+        'padding' => 0,
+    ];
+    return $boxes;
+} );
+
+// Adjust rates returned from the API.
+add_filter( 'auspost_shipping_available_rates', function( $rates, $shipment ) {
+    return array_filter( $rates, fn( $rate ) => $rate['code'] !== 'EXP' );
+}, 10, 2 );
+
+// React when a rate is selected.
+add_action( 'auspost_shipping_rate_selected', function( $rate, $package ) {
+    error_log( 'Selected rate: ' . $rate['code'] );
+}, 10, 2 );
+```
+
 ## Credits
 
 90% of this code was developed by the following people:

--- a/tests/test-box-packer.php
+++ b/tests/test-box-packer.php
@@ -40,4 +40,20 @@ class BoxPackerTest extends TestCase
         $this->assertEquals($dim, $pkg['weight']);
         $this->assertGreaterThan($actual, $pkg['weight']);
     }
+
+    public function test_multiple_boxes_packed()
+    {
+        $boxes = [
+            ['length' => 10, 'width' => 10, 'height' => 10, 'max_weight' => 5, 'padding' => 0],
+        ];
+        $items = [
+            ['length' => 10, 'width' => 10, 'height' => 10, 'weight' => 5, 'qty' => 2],
+        ];
+
+        $packer = new Box_Packer($boxes);
+        $packages = $packer->pack($items);
+
+        $this->assertCount(2, $packages);
+        $this->assertCount(0, $packer->get_unpacked_items());
+    }
 }

--- a/tests/test-contract-rate-client.php
+++ b/tests/test-contract-rate-client.php
@@ -130,5 +130,25 @@ class ContractRateClientTest extends TestCase {
 
         $this->assertSame( [], $rates );
     }
+
+    public function test_get_rates_returns_empty_on_wp_error() {
+        $shipment = [
+            'from_postcode' => '3000',
+            'to_postcode'   => '4000',
+            'weight'        => 1,
+        ];
+
+        $error = new WP_Error( 'http_error', 'fail' );
+
+        \WP_Mock::userFunction( 'get_transient', [ 'return' => false ] );
+        \WP_Mock::userFunction( 'wp_remote_post', [ 'return' => $error ] );
+        \WP_Mock::userFunction( 'is_wp_error', [ 'args' => [ $error ], 'return' => true ] );
+        \WP_Mock::userFunction( 'Auspost_Shipping_Logger::log' );
+
+        $client = new Contract_Rate_Client( 'ACC123', 'key', 'secret' );
+        $rates  = $client->get_rates( $shipment );
+
+        $this->assertSame( [], $rates );
+    }
 }
 

--- a/tests/test-pac-rate-client.php
+++ b/tests/test-pac-rate-client.php
@@ -106,4 +106,25 @@ class PacRateClientTest extends TestCase {
 
         $this->assertSame([], $rates);
     }
+
+    public function test_get_rates_returns_empty_on_wp_error() {
+        $args = [
+            'from_postcode' => '3000',
+            'to_postcode'   => '4000',
+            'weight'        => 1,
+        ];
+
+        $error = new WP_Error( 'http_error', 'fail' );
+
+        \WP_Mock::userFunction( 'get_option', [ 'args' => ['auspost_shipping_pac_api_key'], 'return' => 'APIKEY' ] );
+        \WP_Mock::userFunction( 'get_transient', [ 'return' => false ] );
+        \WP_Mock::userFunction( 'wp_remote_get', [ 'return' => $error ] );
+        \WP_Mock::userFunction( 'is_wp_error', [ 'args' => [ $error ], 'return' => true ] );
+        \WP_Mock::userFunction( 'Auspost_Shipping_Logger::log' );
+
+        $client = new Pac_Rate_Client( 'APIKEY' );
+        $rates  = $client->get_rates( $args );
+
+        $this->assertSame( [], $rates );
+    }
 }

--- a/tests/test-shipping-method.php
+++ b/tests/test-shipping-method.php
@@ -43,6 +43,10 @@ class ShippingMethodTest extends TestCase
         \WP_Mock::userFunction('wc_format_postcode', [
             'return_arg' => 0,
         ]);
+        \WP_Mock::userFunction('apply_filters', [
+            'return_arg' => 1,
+        ]);
+        \WP_Mock::userFunction('do_action');
         \WP_Mock::userFunction('is_wp_error', [
             'return' => false,
         ]);


### PR DESCRIPTION
## Summary
- add filters/actions for customizing boxes and rates
- document API credentials, box setup, and developer hooks
- cover WP_Error scenarios for rate clients and multi-box packing

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bda5e5baa48323b641552fe6767467