### PR TITLE
Add PHP version compatibility check

### DIFF
--- a/auspost-shipping/auspost-shipping.php
+++ b/auspost-shipping/auspost-shipping.php
@@ -37,6 +37,20 @@ if ( ! defined( 'WPINC' ) ) {
  */
 define( 'AUSPOST_SHIPPING_VERSION', '1.0.0' );
 
+if ( version_compare( PHP_VERSION, '7.0', '<' ) ) {
+    add_action(
+        'admin_notices',
+        function () {
+            $class   = 'notice notice-error';
+            $message = __( 'Auspost Shipping requires PHP 7.0 or greater.', 'auspost-shipping' );
+
+            printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
+        }
+    );
+
+    return;
+}
+
 if (!function_exists('is_plugin_active')) {
     include_once(ABSPATH . '/wp-admin/includes/plugin.php');
 }


### PR DESCRIPTION
## Summary
- Halt Auspost Shipping plugin when running on PHP versions lower than 7
- Display an admin notice if PHP version requirement is not met

## Testing
- ⚠️ `composer install` *(failed: CONNECT tunnel failed: 403)*
- ⚠️ `vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be12e4f2b88323ab6b3f9cf446c7c6