### PR TITLE
Simplify WooCommerce dependency check

### DIFF
--- a/auspost-shipping/auspost-shipping.php
+++ b/auspost-shipping/auspost-shipping.php
@@ -50,11 +50,6 @@ if ( version_compare( PHP_VERSION, '7.0', '<' ) ) {
 
     return;
 }
-
-if (!function_exists('is_plugin_active')) {
-    include_once(ABSPATH . '/wp-admin/includes/plugin.php');
-}
-
 /**
 * Display a message advising WooCommerce is required
 */
@@ -102,16 +97,16 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-auspost-shipping.php';
  * @since    1.0.0
  */
 function ausps_check_requirements() {
-    if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
-        $plugin = new Auspost_Shipping();
-        $plugin->run();
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        add_action( 'admin_notices', 'ausps_missing_wc_notice' );
 
-        return true;
+        return false;
     }
 
-    add_action( 'admin_notices', 'ausps_missing_wc_notice' );
+    $plugin = new Auspost_Shipping();
+    $plugin->run();
 
-    return false;
+    return true;
 }
 
 add_action( 'plugins_loaded', 'ausps_check_requirements' );

--- a/tests/test-requirements.php
+++ b/tests/test-requirements.php
@@ -19,11 +19,6 @@ class RequirementsTest extends TestCase
                 return __DIR__ . '/stubs/';
             }
         }
-
-        \WP_Mock::userFunction('is_plugin_active', [
-            'return' => true,
-        ]);
-
         \WP_Mock::userFunction('register_activation_hook');
         \WP_Mock::userFunction('register_deactivation_hook');
 
@@ -37,25 +32,19 @@ class RequirementsTest extends TestCase
         \WP_Mock::tearDown();
     }
 
-    public function test_returns_true_when_woocommerce_active()
-    {
-        \WP_Mock::userFunction('is_plugin_active', [
-            'return' => true,
-            'args' => ['woocommerce/woocommerce.php'],
-        ]);
-
-        $this->assertTrue(ausps_check_requirements());
-    }
-
     public function test_returns_false_and_hooks_notice_when_woocommerce_inactive()
     {
-        \WP_Mock::userFunction('is_plugin_active', [
-            'return' => false,
-            'args' => ['woocommerce/woocommerce.php'],
-        ]);
-
         \WP_Mock::expectActionAdded('admin_notices', 'ausps_missing_wc_notice');
 
         $this->assertFalse(ausps_check_requirements());
+    }
+
+    public function test_returns_true_when_woocommerce_active()
+    {
+        if (!class_exists('WooCommerce')) {
+            class WooCommerce {}
+        }
+
+        $this->assertTrue(ausps_check_requirements());
     }
 }


### PR DESCRIPTION
## Summary
- Remove legacy plugin inclusion for `is_plugin_active`
- Detect WooCommerce via `class_exists` and bail with admin notice if missing
- Update requirement tests to simulate WooCommerce class rather than `is_plugin_active`

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit tests/test-requirements.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be13ee85ac8323badc9ce3713823ad