### PR TITLE
Load text domain immediately during plugin setup

### DIFF
--- a/auspost-shipping/includes/class-auspost-shipping.php
+++ b/auspost-shipping/includes/class-auspost-shipping.php
@@ -147,9 +147,10 @@ class Auspost_Shipping {
 	 */
 	private function set_locale() {
 
-		$plugin_i18n = new Auspost_Shipping_i18n();
+                $plugin_i18n = new Auspost_Shipping_i18n();
 
-		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+                // Load the text domain immediately so translations are available.
+                $plugin_i18n->load_plugin_textdomain();
 
 	}
 


### PR DESCRIPTION
## Summary
- load translation files during plugin construction to ensure immediate availability

## Testing
- ❌ `composer install` (curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)
- ❌ `./vendor/bin/phpunit` (No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68be17a1afc88323951fe45a33a77f34