### PR TITLE
Add explicit parameter and return types to Auspost API get_rates

### DIFF
--- a/auspost-shipping/includes/class-auspost-api.php
+++ b/auspost-shipping/includes/class-auspost-api.php
@@ -90,9 +90,9 @@ if ( ! class_exists( 'Auspost_API' ) ) {
          * hitting the API repeatedly with the same request.
          *
          * @param array $args Request arguments.
-         * @return array|WP_Error Array of rate data or WP_Error on failure.
+         * @return array|WP_Error Array of rate data or a WP_Error on failure.
          */
-        public function get_rates( $args ) {
+        public function get_rates( array $args ): array|WP_Error {
             $url = $this->build_request_url( $args );
             if ( is_wp_error( $url ) ) {
                 return $url;


### PR DESCRIPTION
## Summary
- type-hint the Auspost API `get_rates` method with an array parameter and `array|WP_Error` return
- update method phpdoc accordingly and ensure rate client continues to handle `WP_Error`

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be1ce9d82483239b5202dc7ab5bf90